### PR TITLE
[archimedes] Add Registry class

### DIFF
--- a/archimedes/_version.py
+++ b/archimedes/_version.py
@@ -1,2 +1,2 @@
 # Versions compliant with PEP 440 https://www.python.org/dev/peps/pep-0440
-__version__ = "0.3.0"
+__version__ = "0.5.0"

--- a/archimedes/errors.py
+++ b/archimedes/errors.py
@@ -65,3 +65,9 @@ class ObjectTypeError(BaseError):
     """Error for handling unknown object types"""
 
     message = "%(cause)s"
+
+
+class RegistryError(BaseError):
+    """Error for handling registry errors"""
+
+    message = "%(cause)s"

--- a/archimedes/registry.py
+++ b/archimedes/registry.py
@@ -1,0 +1,194 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2014-2018 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+#
+# Authors:
+#   Valerio Cosentino <valcos@bitergia.com>
+#
+
+import json
+import logging
+import os
+
+from archimedes.errors import NotFoundError, RegistryError
+from archimedes.meta_obj import MetaObj
+from archimedes.utils import load_json
+
+logger = logging.getLogger(__name__)
+
+REGISTRY_NAME = ".registry"
+
+
+class Registry:
+
+    def __init__(self, root_path):
+        """This class allows to manipulate the Kibana objects using aliases, thus avoiding the user
+        to deal with their IDs and titles. The registry is saved in the root folder of Archimedes,
+        with name .registry. The content of the registry is as following:
+        [
+            "1": {
+                    'id': 'Search:_pull_request:false',
+                    'title': 'Search:_pull_request:false',
+                    'type': 'search',
+                    'version': 1
+            },
+            "2": {
+                    'id': '8539ada0-9960-11e8-8771-a349686d998a',
+                    'title': 'dockerhub',
+                    'type': 'index-pattern',
+                    'version': 1
+            },
+            ...
+        ]
+
+        :param root_path: path where the registry will be stored
+        """
+        self.path = os.path.join(root_path, REGISTRY_NAME)
+
+        if not os.path.exists(self.path):
+            self.__create_registry()
+
+        self.content = load_json(self.path)
+
+    def find_all(self, obj_type=None):
+        """Return the entries in the registry. If `obj_type` is none, it returns the
+        content of all the registry. Otherwise, it returns the entries related to the
+        aliases with the given `obj_type`.
+
+        :param obj_type: target object type
+
+        :returns a generator of tuples of aliases and metadata in the registry
+        """
+        if obj_type:
+            for alias in self.content.keys():
+                if self.content[alias]['type'] == obj_type:
+                    meta = MetaObj.create_from_registry(self.content[alias])
+                    yield alias, meta
+        else:
+            for alias in self.content.keys():
+                meta = MetaObj.create_from_registry(self.content[alias])
+                yield alias, meta
+
+    def find(self, alias):
+        """Return the entry linked to an alias in the registry.
+
+        :param alias: target alias
+
+        :returns a tuple composed of an alias and metadata
+        """
+        if alias not in self.content:
+            cause = "Alias %s not found in registry" % alias
+            logger.error(cause)
+            raise NotFoundError(cause=cause)
+
+        meta = MetaObj.create_from_registry(self.content[alias])
+        return alias, meta
+
+    def clear(self):
+        """Clear the registry content.
+
+        :param alias: target alias
+        """
+        self.content.clear()
+
+        self.__save_registry(self.content)
+        logger.info("Registry cleared")
+        return
+
+    def delete(self, alias=None):
+        """Delete an entry in the registry based on a given `alias`.
+
+        :param alias: target alias
+        """
+        if alias not in self.content:
+            cause = "Alias %s not found in registry" % alias
+            logger.error(cause)
+            raise NotFoundError(cause=cause)
+
+        self.content.pop(alias)
+
+        self.__save_registry()
+        logger.info("Alias %s deleted", alias)
+
+    def add(self, meta_obj, force=False):
+        """Add the meta information of a kibana object to the registry.
+
+        :param meta_obj: the target meta object
+        :param force: overwrite an existing registry entry if already exists
+        """
+        duplicate_alias = self.__check_duplicates('id', meta_obj.id)
+
+        if not duplicate_alias:
+            next_key = str(len(self.content.keys()) + 1)
+            self.content[next_key] = json.loads(repr(meta_obj))
+
+            self.__save_registry(self.content)
+            logger.info("Metadata for object %s with alias %s added to the registry", meta_obj.id, next_key)
+            return
+
+        if force:
+            self.content[duplicate_alias] = json.loads(repr(meta_obj))
+
+            logger.info("Metadata for object %s already exists in the registry. Overwriting alias %s",
+                        meta_obj.id, duplicate_alias)
+            self.__save_registry(self.content)
+        else:
+            cause = "Metadata for object %s already exists in the registry" % meta_obj.id
+            logger.error(cause)
+            raise RegistryError(cause=cause)
+
+    def update(self, old_alias, new_alias):
+        """Change the name of an alias with a new one
+
+        :param old_alias: target alias
+        :param new_alias: new alias
+        """
+        if old_alias not in self.content:
+            cause = "Alias %s not found in registry" % old_alias
+            logger.error(cause)
+            raise NotFoundError(cause=cause)
+
+        if new_alias in self.content:
+            cause = "Alias %s already in use" % new_alias
+            logger.error(cause)
+            raise RegistryError(cause=cause)
+
+        self.content[new_alias] = self.content.pop(old_alias)
+
+        self.__save_registry(self.content)
+        logger.info("Alias %s updated with %s", old_alias, new_alias)
+
+    def __create_registry(self):
+        with open(self.path, 'w+') as f:
+            f.write('{}')
+            logger.info("Registry created at %s", self.path)
+
+    def __save_registry(self, content):
+        with open(self.path, 'w') as f:
+            dumped = json.dumps(content, sort_keys=True, indent=4)
+            f.write(dumped)
+            logger.info("Registry saved")
+
+    def __check_duplicates(self, attr, value):
+        alias = None
+        for k in self.content.keys():
+            entry = self.content[k]
+            if entry[attr] == value:
+                alias = k
+                break
+
+        return alias

--- a/tests/data/registry_full
+++ b/tests/data/registry_full
@@ -1,0 +1,79 @@
+{
+    "1": {
+        "id": "maniphest",
+        "title": "maniphest",
+        "type": "index-pattern",
+        "updated_at": "2019-02-12T15:38:42.905Z",
+        "version": 1
+    },
+    "10": {
+        "id": "Maniphest-Search:_status:Open",
+        "title": "Maniphest Search:_status:Open",
+        "type": "search",
+        "updated_at": "2019-02-12T15:38:41.705Z",
+        "version": 1
+    },
+    "11": {
+        "id": "Maniphest-Backlog",
+        "title": "Maniphest Backlog",
+        "type": "dashboard",
+        "updated_at": "2019-02-12T15:38:52.132Z",
+        "version": 1
+    },
+    "2": {
+        "id": "maniphest_openissues_per_organization",
+        "title": "maniphest_openissues_per_organization",
+        "type": "visualization",
+        "updated_at": "2019-02-12T15:38:51.091Z",
+        "version": 1
+    },
+    "3": {
+        "id": "maniphest_backlog",
+        "title": "maniphest_backlog",
+        "type": "visualization",
+        "updated_at": "2019-02-12T15:38:47.023Z",
+        "version": 1
+    },
+    "4": {
+        "id": "maniphest_openissues_submitters",
+        "title": "maniphest_openissues_submitters",
+        "type": "visualization",
+        "updated_at": "2019-02-12T15:38:49.057Z",
+        "version": 1
+    },
+    "5": {
+        "id": "maniphest_openissues_per_project",
+        "title": "maniphest_openissues_per_project",
+        "type": "visualization",
+        "updated_at": "2019-02-12T15:38:44.969Z",
+        "version": 1
+    },
+    "6": {
+        "id": "maniphest_openissues_statistics",
+        "title": "maniphest_openissues_statistics",
+        "type": "visualization",
+        "updated_at": "2019-02-12T15:38:43.959Z",
+        "version": 1
+    },
+    "7": {
+        "id": "maniphest_openissues_backlog_accumulated_time",
+        "title": "maniphest_openissues_backlog_accumulated_time",
+        "type": "visualization",
+        "updated_at": "2019-02-12T15:38:48.023Z",
+        "version": 1
+    },
+    "8": {
+        "id": "maniphest_openissues_backlog",
+        "title": "maniphest_openissues_backlog",
+        "type": "visualization",
+        "updated_at": "2019-02-12T15:38:45.990Z",
+        "version": 1
+    },
+    "9": {
+        "id": "maniphest_openissues_assignee_orgs",
+        "title": "maniphest_openissues_assignee_orgs",
+        "type": "visualization",
+        "updated_at": "2019-02-12T15:38:50.074Z",
+        "version": 1
+    }
+}

--- a/tests/data/registry_slim
+++ b/tests/data/registry_slim
@@ -1,0 +1,14 @@
+{
+    "1": {
+        "id": "0b84fff0-b1b6-11e8-8aac-ef7fd4d8cbad",
+        "title": "gitlab-issues_submitters_by_organization",
+        "type": "visualization",
+        "version": 1
+    },
+    "2": {
+        "id": "7c2496c0-b013-11e8-8771-a349686d998a",
+        "title": "gitlab",
+        "type": "index-pattern",
+        "version": 1
+    }
+}

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -107,5 +107,14 @@ class TestNotFoundError(unittest.TestCase):
         self.assertEqual('object not found', str(e))
 
 
+class TestRegistryError(unittest.TestCase):
+
+    def test_message(self):
+        """Test RegistryError message"""
+
+        e = errors.RegistryError(cause='error on registry')
+        self.assertEqual('error on registry', str(e))
+
+
 if __name__ == "__main__":
     unittest.main(warnings='ignore')

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,323 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2014-2018 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+#
+# Authors:
+#   Valerio Cosentino <valcos@bitergia.com>
+#
+
+import os
+import shutil
+import tempfile
+
+import unittest
+
+from archimedes.clients.dashboard import VISUALIZATION
+from archimedes.errors import NotFoundError, RegistryError
+from archimedes.meta_obj import MetaObj
+from archimedes.registry import Registry, REGISTRY_NAME
+
+
+def read_file(filename, mode='r'):
+    with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), filename), mode) as f:
+        content = f.read()
+    return content
+
+
+def copy_content(filename, target_path):
+    content = read_file(filename)
+
+    with open(target_path, 'w') as f:
+        f.write(content)
+
+
+DASHBOARD_OBJ = {
+    "attributes": {
+        "description": "GitLab Issues panel by Bitergia",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+            "searchSourceJSON": "..."
+        },
+        "optionsJSON": "{\"darkTheme\":false,\"hidePanelTitles\":false,\"useMargins\":true}",
+        "panelsJSON": "...",
+        "timeRestore": "false",
+        "title": "GitLab Issues",
+        "uiStateJSON": "...",
+        "version": 1
+    },
+    "id": "2e968fe0-b1bb-11e8-8aac-ef7fd4d8cbad",
+    "type": "dashboard",
+    "updated_at": "2019-01-24T13:20:08.902Z",
+    "version": 9
+}
+
+
+VISUALIZATION_OBJ_DUPLICATED = {
+    "attributes": {
+        "fieldFormatMap": "...",
+        "fields": "...",
+        "timeFieldName": "grimoire_creation_date",
+        "title": "gitlab"
+    },
+    "id": "7c2496c0-b013-11e8-8771-a349686d998a",
+    "type": "index-pattern",
+    "version": 1
+}
+
+
+class TestRegistry(unittest.TestCase):
+    """Registry tests"""
+
+    def setUp(self):
+        self.tmp_path = tempfile.mkdtemp(prefix='archimedes_')
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp_path)
+
+    def test_initialization(self):
+        """Test whether attributes are initialized"""
+
+        registry_path = os.path.join(self.tmp_path, REGISTRY_NAME)
+        self.assertFalse(os.path.exists(registry_path))
+
+        registry = Registry(self.tmp_path)
+
+        self.assertEqual(registry.path, registry_path)
+        self.assertTrue(os.path.exists(registry_path))
+
+    def test_find_all(self):
+        """Test whether the find method returns all entries when no obj type is given"""
+
+        registry = Registry(self.tmp_path)
+        copy_content('data/registry_full', registry.path)
+
+        tuples = [t for t in registry.find_all()]
+
+        self.assertEqual(len(tuples), 11)
+
+        alias = tuples[0][0]
+        expected_alias = '1'
+        self.assertEqual(alias, expected_alias)
+
+        info = tuples[0][1]
+        expected_info = {
+            'id': 'maniphest',
+            'title': 'maniphest',
+            'type': 'index-pattern',
+            'updated_at': '2019-02-12T15:38:42.905Z',
+            'version': 1
+        }
+
+        self.assertIsInstance(info, MetaObj)
+        self.assertEqual(expected_info['id'], info.id)
+        self.assertEqual(expected_info['title'], info.title)
+        self.assertEqual(expected_info['type'], info.type)
+        self.assertEqual(expected_info['updated_at'], info.updated_at)
+        self.assertEqual(expected_info['version'], info.version)
+
+    def test_find_all_type(self):
+        """Test whether the find method returns only the aliases linked to a given obj type"""
+
+        registry = Registry(self.tmp_path)
+        copy_content('data/registry_full', registry.path)
+
+        tuples = [t for t in registry.find_all(obj_type=VISUALIZATION)]
+
+        self.assertEqual(len(tuples), 8)
+
+        alias = tuples[0][0]
+        expected_alias = '2'
+        self.assertEqual(alias, expected_alias)
+
+        info = tuples[0][1]
+        expected_info = {
+            'id': 'maniphest_openissues_per_organization',
+            'title': 'maniphest_openissues_per_organization',
+            'type': 'visualization',
+            'updated_at': '2019-02-12T15:38:51.091Z',
+            'version': 1
+        }
+
+        self.assertIsInstance(info, MetaObj)
+        self.assertEqual(expected_info['id'], info.id)
+        self.assertEqual(expected_info['title'], info.title)
+        self.assertEqual(expected_info['type'], info.type)
+        self.assertEqual(expected_info['updated_at'], info.updated_at)
+        self.assertEqual(expected_info['version'], info.version)
+
+    def test_find_alias(self):
+        """Test whether the find method returns a single entry when an alias is given"""
+
+        registry = Registry(self.tmp_path)
+        copy_content('data/registry_full', registry.path)
+
+        alias, meta = registry.find('1')
+
+        expected_alias = '1'
+        self.assertEqual(alias, expected_alias)
+
+        expected_info = {
+            'id': 'maniphest',
+            'title': 'maniphest',
+            'type': 'index-pattern',
+            'updated_at': '2019-02-12T15:38:42.905Z',
+            'version': 1
+        }
+
+        self.assertIsInstance(meta, MetaObj)
+        self.assertEqual(expected_info['id'], meta.id)
+        self.assertEqual(expected_info['title'], meta.title)
+        self.assertEqual(expected_info['type'], meta.type)
+        self.assertEqual(expected_info['updated_at'], meta.updated_at)
+        self.assertEqual(expected_info['version'], meta.version)
+
+    def test_find_not_found(self):
+        """Test whether an exception is thrown when an alias is not found"""
+
+        registry = Registry(self.tmp_path)
+        copy_content('data/registry_full', registry.path)
+
+        with self.assertRaises(NotFoundError):
+            _ = [t for t in registry.find(alias='x')]
+
+    def test_clear(self):
+        """Test whether the registry is cleared"""
+
+        registry = Registry(self.tmp_path)
+        copy_content('data/registry_full', registry.path)
+
+        tuples = [t for t in registry.find_all()]
+        self.assertEqual(len(tuples), 11)
+
+        registry.clear()
+
+        tuples = [t for t in registry.find_all()]
+        self.assertEqual(len(tuples), 0)
+
+    def test_delete_alias(self):
+        """Test whether an alias is removed from the registry"""
+
+        registry = Registry(self.tmp_path)
+        copy_content('data/registry_full', registry.path)
+
+        tuples = [t for t in registry.find_all()]
+        self.assertEqual(len(tuples), 11)
+
+        registry.delete(alias='1')
+
+        tuples = [t for t in registry.find_all()]
+        self.assertEqual(len(tuples), 10)
+
+    def test_delete_not_found(self):
+        """Test whether an exception is thrown when an alias is not found"""
+
+        registry = Registry(self.tmp_path)
+        copy_content('data/registry_full', registry.path)
+
+        with self.assertRaises(NotFoundError):
+            _ = [t for t in registry.delete(alias='x')]
+
+    def test_add_alias(self):
+        """Test whether an alias is added to the registry"""
+
+        registry = Registry(self.tmp_path)
+        copy_content('data/registry_full', registry.path)
+
+        tuples = [t for t in registry.find_all()]
+        self.assertEqual(len(tuples), 11)
+
+        new_alias = '12'
+        new_obj = MetaObj.create_from_obj(DASHBOARD_OBJ)
+        registry.add(new_obj)
+
+        tuples = [t for t in registry.find_all()]
+        self.assertEqual(len(tuples), 12)
+
+        alias, meta = next(registry.find(new_alias))
+
+        self.assertEqual(meta.id, DASHBOARD_OBJ['id'])
+        self.assertEqual(meta.title, DASHBOARD_OBJ['attributes']['title'])
+        self.assertEqual(meta.type, DASHBOARD_OBJ['type'])
+        self.assertEqual(meta.updated_at, DASHBOARD_OBJ['updated_at'])
+        self.assertEqual(meta.version, DASHBOARD_OBJ['version'])
+
+    def test_add_alias_duplicated(self):
+        """Test whether an exception is thrown when the same object already exists in the registry"""
+
+        registry = Registry(self.tmp_path)
+        copy_content('data/registry_slim', registry.path)
+
+        new_obj = MetaObj.create_from_obj(VISUALIZATION_OBJ_DUPLICATED)
+        with self.assertRaises(RegistryError):
+            registry.add(new_obj)
+
+    def test_add_alias_force(self):
+        """Test whether an object is overwritten if it already exists in the registry and the param force is on"""
+
+        registry = Registry(self.tmp_path)
+        copy_content('data/registry_slim', registry.path)
+
+        tuples = [t for t in registry.find_all()]
+        self.assertEqual(len(tuples), 2)
+
+        new_obj = MetaObj.create_from_obj(VISUALIZATION_OBJ_DUPLICATED)
+        registry.add(new_obj, force=True)
+
+        tuples = [t for t in registry.find_all()]
+        self.assertEqual(len(tuples), 2)
+
+    def test_update(self):
+        """Test whether the name of an alias is updated"""
+
+        registry = Registry(self.tmp_path)
+        copy_content('data/registry_slim', registry.path)
+
+        tuples = [t for t in registry.find_all()]
+        alias = tuples[0][0]
+        self.assertEqual(alias, '1')
+        alias = tuples[1][0]
+        self.assertEqual(alias, '2')
+
+        registry.update('1', 'x')
+
+        tuples = [t for t in registry.find_all()]
+        alias = tuples[0][0]
+        self.assertEqual(alias, '2')
+        alias = tuples[1][0]
+        self.assertEqual(alias, 'x')
+
+    def test_update_not_found(self):
+        """Test whether an exception is thrown when an alias is not found"""
+
+        registry = Registry(self.tmp_path)
+        copy_content('data/registry_slim', registry.path)
+
+        with self.assertRaises(NotFoundError):
+            _ = [t for t in registry.update('3', '4')]
+
+    def test_update_new_alias_in_use(self):
+        """Test whether an exception is thrown when the new alias is already used"""
+
+        registry = Registry(self.tmp_path)
+        copy_content('data/registry_slim', registry.path)
+
+        with self.assertRaises(RegistryError):
+            _ = [t for t in registry.update('1', '2')]
+
+
+if __name__ == "__main__":
+    unittest.main(warnings='ignore')


### PR DESCRIPTION
This PR includes the class `Registry`, which allows to manipulate the Kibana objects using aliases, thus avoiding the user to deal with their IDs and titles. The registry is saved in the root folder of Archimedes,
with name .registry. Furthermore, a new exception to model issues when performing operations over the registry has been added to the errors.py file