### PR TITLE
[kibana] Add method `find_all`

### DIFF
--- a/archimedes/_version.py
+++ b/archimedes/_version.py
@@ -1,2 +1,2 @@
 # Versions compliant with PEP 440 https://www.python.org/dev/peps/pep-0440
-__version__ = "0.3.0"
+__version__ = "0.6.0"

--- a/archimedes/kibana.py
+++ b/archimedes/kibana.py
@@ -41,7 +41,6 @@ class Kibana:
 
     :param base_url: the Kibana URL
     """
-
     def __init__(self, base_url):
         self.base_url = base_url
         self.dashboard = Dashboard(base_url)
@@ -148,3 +147,14 @@ class Kibana:
             raise NotFoundError(cause=cause)
 
         return found_obj
+
+    def find_all(self):
+        """Find all objects stored in Kibana.
+
+        :returns a generator of Kibana objects
+        """
+        url = urijoin(self.base_url, self.saved_objects.API_SAVED_OBJECTS_URL)
+
+        for page_objs in self.saved_objects.fetch_objs(url):
+            for obj in page_objs:
+                yield obj

--- a/tests/test_kibana.py
+++ b/tests/test_kibana.py
@@ -106,7 +106,7 @@ class TestKibana(unittest.TestCase):
     """Kibana tests"""
 
     def test_initialization(self):
-        """Test whether attributes are initializated"""
+        """Test whether attributes are initialized"""
 
         kibana = Kibana(KIBANA_URL)
 
@@ -160,7 +160,7 @@ class TestKibana(unittest.TestCase):
         with self.assertRaises(ObjectTypeError):
             kibana.export_by_title("unknown", "unknown")
 
-    def test_export_by_title_not_found(self):
+    def test_export_by_title_not_found_error(self):
         """Test whether an error is thrown when the object is not found"""
 
         kibana = MockedKibana(KIBANA_URL, OBJECTS)
@@ -203,6 +203,16 @@ class TestKibana(unittest.TestCase):
 
         with self.assertRaises(NotFoundError):
             kibana.find_by_id("unknown", "unknown")
+
+    def test_find_all(self):
+        """Test whether all objects in Kibana are retrieved"""
+
+        kibana = MockedKibana(KIBANA_URL, OBJECTS)
+        objs = [obj for obj in kibana.find_all()]
+
+        self.assertEqual(len(objs), 2)
+        self.assertDictEqual(objs[0], OBJECTS[0][0])
+        self.assertDictEqual(objs[1], OBJECTS[0][1])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR allows to retrieve all objects stored in Kibana. This feature is needed to inspect the content of the Kibana instance.