### PR TITLE
[archimedes] Support for new features (registry and inspect)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Currently, Archimedes is able to perform the following operations
 
 - **Import objects from disk** 
     
-  Locate an object based on its type and ID or title on disk and import it to Kibana. If 
+  Locate an object based on its alias or its type and ID or title on disk and import it to Kibana. If 
   `find` is set to true, it also loads the related objects (i.e., visualizations, 
   search and index pattern).
   
@@ -35,15 +35,15 @@ Currently, Archimedes is able to perform the following operations
 archimedes
 http://...                        # Kibana URL (required)
 ...                               # Archimedes folder (required)
---obj-type ...                    # Type of the object to import (required)
---obj-id/title ...                # ID/title of the object to import (required)
+--obj-type ...                    # type of the object to import
+--obj-id/title/alias ...          # ID/title/alias of the object to import
 --find                            # find and import also the objects referenced in the input object
 --force                           # overwrite any existing objects on ID conflict
 ```
   
 - **Export objects to disk**
 
-  Locate an object by its ID or title in Kibana and export it to a folder path. The exported data 
+  Locate an object by its ID, alias or title in Kibana and export it to a folder path. The exported data 
   is divided into several folders according to the type of the objects exported 
   (i.e., visualizations, searches and index patterns).
 
@@ -54,10 +54,81 @@ archimedes
 http://...                        # Kibana URL (required)
 ...                               # Archimedes folder (required)
 --export                          # action (required)
---obj-type ...                    # Type of the object to export (required)
---obj-id/title ...                # ID/title of the object to export (required)
+--obj-type ...                    # type of the object to export
+--obj-id/title/alias ...          # ID/title/alias of the object to export
 --force                           # overwrite an existing file on file name conflict
 --index-pattern                   # export the index pattern related to the target object
+```
+
+- **Inspect objects handled by Archimedes**
+  
+  List the objects stored in Kibana or in the Archimedes folder.
+  
+```buildoutcfg
+archimedes
+http://...                        # Kibana URL (required)
+...                               # Archimedes folder (required)
+--inspect                         # action (required)
+--local                           # inspect objects in the Archimedes folder 
+--remote                          # inspect objects in Kibana
+```
+
+- **Populate the Archimedes registry**
+  
+  Populate the registry file based on the objects stored in Kibana. The registry will include a
+  list of entries which contain the metadata of the Kibana objects and the associated aliases.
+  
+```buildoutcfg
+archimedes
+http://...                        # Kibana URL (required)
+...                               # Archimedes folder (required)
+--registry                        # action (required)
+--populate                        # action (required)
+--force                           # overwrite an existing object on ID conflict
+```
+
+- **Show the Archimedes registry**
+  
+  Show the content of the registry. If `alias` and `obj_type` are null, it returns the
+  content of all the registry. Otherwise, it returns the information related to the single `alias` or
+  the aliases associated with the given `obj_type`.
+  
+```buildoutcfg
+archimedes
+http://...                        # Kibana URL (required)
+...                               # Archimedes folder (required)
+--registry                        # action (required)
+--show                            # action (required)
+--alias ...                       # the name of the target alias
+--obj-type ...                    # type of the objects to list
+```
+
+- **Delete the Archimedes registry**
+  
+  Delete the content of the registry. If `alias` is not null, it deletes only the information
+  corresponding to that alias.
+  
+```buildoutcfg
+archimedes
+http://...                        # Kibana URL (required)
+...                               # Archimedes folder (required)
+--registry                        # action (required)
+--delete                          # action (required)
+--alias ...                       # the name of the target alias
+```
+
+- **Update the Archimedes registry**
+  
+  Change a given alias saved in the registry with a new alias.
+  
+```buildoutcfg
+archimedes
+http://...                        # Kibana URL (required)
+...                               # Archimedes folder (required)
+--registry                        # action (required)
+--update                          # action (required)
+--alias ...                       # the name of the target alias
+--new-alias ...                   # the name of the new alias
 ```
 
 ## Examples
@@ -81,6 +152,15 @@ http://admin:admin@localhost:5601
 --import
 --obj-type visualization
 --obj-id git_main_numbers
+```
+
+- **Import a visualization by alias** 
+```buildoutcfg
+archimedes
+http://admin:admin@localhost:5601
+/home
+--import
+--obj-alias 1
 ```
 
 - **Import a dashboard by content title and related objects**
@@ -116,6 +196,16 @@ http://admin:admin@localhost:5601
 --force
 ```
 
+- **Export a dashboard by alias**
+```buildoutcfg
+archimedes
+http://admin:admin@localhost:5601
+/home
+--export
+--obj-alias 1
+--force
+```
+
 - **Export a visualization by ID and its index pattern**
 ```buildoutcfg
 archimedes
@@ -126,6 +216,93 @@ http://admin:admin@localhost:5601
 --obj-id git_commits_organizations
 --force
 --index-pattern
+```
+
+- **Inspect the objects stored in Kibana**
+```buildoutcfg
+archimedes
+http://admin:admin@localhost:5601
+/home
+--inspect 
+--remote
+```
+
+- **Inspect the objects stored on disk**
+```buildoutcfg
+archimedes
+http://admin:admin@localhost:5601
+/home
+--inspect 
+--local
+```
+
+- **Populate the registry, forcing the overwriting**
+```buildoutcfg
+archimedes
+http://admin:admin@localhost:5601
+/home
+--registry 
+--populate 
+--force
+```
+
+- **Show the full registry**
+```buildoutcfg
+archimedes
+http://admin:admin@localhost:5601
+/home
+--registry 
+--show
+```
+
+- **Show the information of a single alias in the registry**
+```buildoutcfg
+archimedes
+http://admin:admin@localhost:5601
+/home
+--registry 
+--show
+--alias x
+```
+
+- **Show the information of aliases of a given type**
+```buildoutcfg
+archimedes
+http://admin:admin@localhost:5601
+/home
+--registry 
+--show
+--obj-type dashboard
+```
+
+- **Clear the registry content**
+```buildoutcfg
+archimedes
+http://admin:admin@localhost:5601
+/home
+--registry 
+--clear
+```
+
+- **Delete a given alias from the registry**
+```buildoutcfg
+archimedes
+http://admin:admin@localhost:5601
+/home
+--registry 
+--delete
+--alias x
+```
+
+- **Update an existing alias in the registry**
+```buildoutcfg
+archimedes
+http://admin:admin@localhost:5601
+/home
+--registry 
+--update
+--alias x
+--new-alias y
 ```
 
 

--- a/archimedes/_version.py
+++ b/archimedes/_version.py
@@ -1,2 +1,2 @@
 # Versions compliant with PEP 440 https://www.python.org/dev/peps/pep-0440
-__version__ = "0.7.0"
+__version__ = "0.8.0"

--- a/archimedes/archimedes.py
+++ b/archimedes/archimedes.py
@@ -22,15 +22,17 @@
 
 import logging
 
-from archimedes.kibana import Kibana
 from archimedes.clients.dashboard import (DASHBOARD,
                                           INDEX_PATTERN,
                                           SEARCH,
                                           VISUALIZATION)
 from archimedes.errors import (ExportError,
-                               FileTypeError,
-                               ImportError)
+                               ImportError,
+                               ObjectTypeError)
+from archimedes.kibana import Kibana
+from archimedes.kibana_obj_meta import KibanaObjMeta
 from archimedes.manager import Manager
+from archimedes.registry import Registry
 from archimedes.utils import load_json
 
 logger = logging.getLogger(__name__)
@@ -47,9 +49,10 @@ class Archimedes:
     def __init__(self, url, root_path):
         self.kibana = Kibana(url)
         self.manager = Manager(root_path)
+        self.registry = Registry(root_path)
 
-    def import_from_disk(self, obj_type, obj_id=None, obj_title=None, find=False, force=False):
-        """Locate an object based on its type and ID or title on disk and import it to Kibana.
+    def import_from_disk(self, obj_type=None, obj_id=None, obj_title=None, obj_alias=None, find=False, force=False):
+        """Locate an object based on its type and ID, title or alias on disk and import it to Kibana.
         If `find` is set to true, it also loads the related objects (i.e., visualizations,
         search and index pattern) using the `manager`.
 
@@ -59,19 +62,30 @@ class Archimedes:
         :param obj_type: type of the target object
         :param obj_id: ID of the target object
         :param obj_title: title of the target object
+        :param obj_alias: alias of the target object
         :param find: find the objects referenced in the file
 
         :param force: overwrite any existing objects on ID conflict
         """
-        folder_path = self.manager.build_folder_path(obj_type)
-
-        if obj_id:
-            file_name = self.manager.build_file_name(obj_type, obj_id)
-            file_path = self.manager.find_file_by_name(folder_path, file_name)
-        elif obj_title:
-            file_path = self.manager.find_file_by_content_title(folder_path, obj_title)
+        if obj_alias:
+            alias, meta = self.registry.find(obj_alias)
+            target_obj_type = meta.type
+            target_obj_id = meta.id
+            target_obj_title = None
         else:
-            cause = "Object id and title cannot be null"
+            target_obj_type = obj_type
+            target_obj_id = obj_id
+            target_obj_title = obj_title
+
+        folder_path = self.manager.build_folder_path(target_obj_type)
+
+        if target_obj_id:
+            file_name = self.manager.build_file_name(target_obj_type, target_obj_id)
+            file_path = self.manager.find_file_by_name(folder_path, file_name)
+        elif target_obj_title:
+            file_path = self.manager.find_file_by_content_title(folder_path, target_obj_title)
+        else:
+            cause = "Object id, title or alias cannot be null"
             logger.error(cause)
             raise ImportError(cause=cause)
 
@@ -86,25 +100,25 @@ class Archimedes:
             self.__import_objects([file_path], force)
             return
 
-        if obj_type == DASHBOARD:
+        if target_obj_type == DASHBOARD:
             files = self.manager.find_dashboard_files(file_path)
-        elif obj_type == VISUALIZATION:
+        elif target_obj_type == VISUALIZATION:
             files = self.manager.find_visualization_files(file_path)
-        elif obj_type == SEARCH:
+        elif target_obj_type == SEARCH:
             files = self.manager.find_search_files(file_path)
-        elif obj_type == INDEX_PATTERN:
-            cause = "Find not supported for %s" % obj_type
+        elif target_obj_type == INDEX_PATTERN:
+            cause = "Find not supported for %s" % target_obj_type
             logger.error(cause)
             raise ImportError(cause=cause)
         else:
-            cause = "Object type %s not known" % obj_type
+            cause = "Object type %s not known" % target_obj_type
             logger.error(cause)
-            raise FileTypeError(cause=cause)
+            raise ObjectTypeError(cause=cause)
 
         self.__import_objects(files, force=force)
 
-    def export_to_disk(self, obj_type, obj_id=None, obj_title=None, force=False, index_pattern=False):
-        """Locate an object based on its type and ID or title in Kibana and export it to disk.
+    def export_to_disk(self, obj_type=None, obj_id=None, obj_title=None, obj_alias=None, force=False, index_pattern=False):
+        """Locate an object based on its type and ID, title or alias in Kibana and export it to disk.
         The exported data is divided into several folders according to the type of the objects exported
         (i.e., visualizations, searches and index patterns).
 
@@ -114,6 +128,7 @@ class Archimedes:
         :param obj_type: type of the target object
         :param obj_id: ID of the target object
         :param obj_title: title of the target object
+        :param obj_alias: alias of the target object
         :param force: overwrite an existing file on file name conflict
         :param index_pattern: export also the index pattern
         """
@@ -121,8 +136,11 @@ class Archimedes:
             obj = self.kibana.export_by_id(obj_type, obj_id)
         elif obj_title:
             obj = self.kibana.export_by_title(obj_type, obj_title)
+        elif obj_alias:
+            alias, meta = self.registry.find(obj_alias)
+            obj = self.kibana.export_by_id(meta.type, meta.id)
         else:
-            cause = "Object id and title cannot be null"
+            cause = "Object id, title or alias cannot be null"
             logger.error(cause)
             raise ExportError(cause=cause)
 

--- a/archimedes/archimedes.py
+++ b/archimedes/archimedes.py
@@ -26,8 +26,8 @@ from archimedes.clients.dashboard import (DASHBOARD,
                                           INDEX_PATTERN,
                                           SEARCH,
                                           VISUALIZATION)
-from archimedes.errors import (ExportError,
-                               ImportError,
+from archimedes.errors import (DataExportError,
+                               DataImportError,
                                ObjectTypeError)
 from archimedes.kibana import Kibana
 from archimedes.kibana_obj_meta import KibanaObjMeta
@@ -87,7 +87,7 @@ class Archimedes:
         else:
             cause = "Object id, title or alias cannot be null"
             logger.error(cause)
-            raise ImportError(cause=cause)
+            raise DataImportError(cause=cause)
 
         json_content = load_json(file_path)
 
@@ -109,7 +109,7 @@ class Archimedes:
         elif target_obj_type == INDEX_PATTERN:
             cause = "Find not supported for %s" % target_obj_type
             logger.error(cause)
-            raise ImportError(cause=cause)
+            raise DataImportError(cause=cause)
         else:
             cause = "Object type %s not known" % target_obj_type
             logger.error(cause)
@@ -142,7 +142,7 @@ class Archimedes:
         else:
             cause = "Object id, title or alias cannot be null"
             logger.error(cause)
-            raise ExportError(cause=cause)
+            raise DataExportError(cause=cause)
 
         self.__export_objects(obj, force, index_pattern)
 

--- a/archimedes/clients/dashboard.py
+++ b/archimedes/clients/dashboard.py
@@ -25,7 +25,7 @@ import logging
 import requests
 
 from archimedes.clients.http import HttpClient
-from archimedes.errors import ExportError
+from archimedes.errors import DataExportError
 from grimoirelab_toolkit.uris import urijoin
 
 DASHBOARD = "dashboard"
@@ -68,12 +68,12 @@ class Dashboard(HttpClient):
                 msg = errors[0]
                 cause = "Impossible to export dashboard with id %s, %s" % (dashboard_id, msg)
                 logger.error(cause)
-                raise ExportError(cause=cause)
+                raise DataExportError(cause=cause)
         except requests.exceptions.HTTPError as error:
             if error.response.status_code == 400:
                 cause = "Impossible to export dashboard with id %s" % dashboard_id
                 logger.error(cause)
-                raise ExportError(cause=cause)
+                raise DataExportError(cause=cause)
             else:
                 raise error
 

--- a/archimedes/errors.py
+++ b/archimedes/errors.py
@@ -37,7 +37,7 @@ class BaseError(Exception):
         return self.msg
 
 
-class ImportError(BaseError):
+class DataImportError(BaseError):
     """Error for handling import errors"""
 
     message = "%(cause)s"
@@ -49,7 +49,7 @@ class FileTypeError(BaseError):
     message = "%(cause)s"
 
 
-class ExportError(BaseError):
+class DataExportError(BaseError):
     """Error for handling export errors"""
 
     message = "%(cause)s"

--- a/bin/archimedes
+++ b/bin/archimedes
@@ -71,6 +71,7 @@ def get_params_parser():
     parser.add_argument('--obj-type', dest='obj_type', help='Type of the object to import/export')
     parser.add_argument('--obj-id', dest='obj_id', help='ID of the object to import/export')
     parser.add_argument('--obj-title', dest='obj_title', help='Title of the object to import/export')
+    parser.add_argument('--obj-alias', dest='obj_alias', help='Alias of the object to import/export')
     parser.add_argument('--force', dest='force', action='store_true', help='Force overwrite')
 
     group_import = parser.add_argument_group('Import')
@@ -81,10 +82,30 @@ def get_params_parser():
     group_export.add_argument('--index-pattern', dest='index_pattern', action='store_true',
                               help='Export the index pattern related to the target object')
 
+    group_inspect = parser.add_argument_group('Inspect')
+    exclusive_inspect = group_inspect.add_mutually_exclusive_group()
+    exclusive_inspect.add_argument('--local', dest='local', action='store_true',
+                                   help='List objects on disk')
+    exclusive_inspect.add_argument('--remote', dest='remote', action='store_true',
+                                   help='List objects in Kibana')
+
+    group_registry = parser.add_argument_group('Registry')
+    exclusive_registry = group_registry.add_mutually_exclusive_group()
+    exclusive_registry.add_argument('--show', dest='show', action='store_true', help='Show the content of the registry')
+    exclusive_registry.add_argument('--update', dest='update', action='store_true', help='Update an alias in the registry')
+    exclusive_registry.add_argument('--populate', dest='populate', action='store_true', help='Populate the registry based on the objects in Kibana')
+    exclusive_registry.add_argument('--clear', dest='clear', action='store_true', help='Delete the content of the registry')
+    exclusive_registry.add_argument('--delete', dest='delete', action='store_true', help='Delete an alias from the registry')
+
+    group_registry.add_argument('--alias', dest='alias', help='Target alias', default=None)
+    group_registry.add_argument('--new-alias', dest='new_alias', help='New alias value', default=None)
+
     exclusive = parser.add_mutually_exclusive_group(required=True)
     exclusive.add_argument('--import', dest='import_objs', action='store_true',
                            help='Import Kibana objects from files')
     exclusive.add_argument('--export', dest='export_objs', action='store_true', help='Export Kibana objects to a file')
+    exclusive.add_argument('--inspect', dest='inspect', action='store_true', help='List the objects managed by archimedes')
+    exclusive.add_argument('--registry', dest='registry', action='store_true', help='Manage archimedes registry')
 
     if len(sys.argv) == 1:
         parser.print_help()
@@ -109,22 +130,38 @@ def get_params():
         logging.error("Missing root path")
         error = 1
 
-    if args.import_objs and args.export_objs:
-        logging.error("Archimedes requires --import or --export")
-        error = 1
+    if args.import_objs or args.export_objs:
+        if not args.obj_type and not args.obj_alias:
+            logging.error("Import/Export by ID or title requires --obj-type")
+            error = 1
 
-    if not args.obj_type:
-        logging.error("Archimedes requires --obj-type")
-        error = 1
-
-    if not xor(bool(args.obj_id), bool(args.obj_title)):
-        logging.error("Archimedes requires --obj-id or --obj-title")
-        error = 1
+        if not bool(args.obj_id) and not bool(args.obj_title) and not bool(args.obj_alias):
+            logging.error("Import/Export requires --obj-id, --obj-title or --obj-alias")
+            error = 1
 
     if args.export_objs:
         if args.obj_type == INDEX_PATTERN and args.index_pattern:
             logging.error("Export index-pattern param is not valid for index-pattern objects")
             error = 1
+
+    if args.inspect:
+        if not xor(bool(args.local), bool(args.remote)):
+            logging.error("Inspect requires --local or --remote")
+            error = 1
+
+    if args.registry:
+        if args.update:
+            if not args.alias or not args.new_alias:
+                logging.error("Update on registry requires --alias and --new-alias")
+                error = 1
+        if args.show:
+            if args.alias and args.obj_type:
+                logging.error("Show on registry accepts no params, --alias or --obj-type")
+                error = 1
+        if args.delete:
+            if not args.alias:
+                logging.error("Delete on registry requires --alias")
+                error = 1
 
     if error:
         sys.exit(1)
@@ -145,12 +182,41 @@ def main():
     elif args.import_objs and args.obj_title:
         archimedes.import_from_disk(obj_type=args.obj_type, obj_title=args.obj_title,
                                     find=args.find, force=args.force)
+    elif args.import_objs and args.obj_alias:
+        archimedes.import_from_disk(obj_type=None, obj_alias=args.obj_alias,
+                                    find=args.find, force=args.force)
+
     elif args.export_objs and args.obj_id:
         archimedes.export_to_disk(obj_type=args.obj_type, obj_id=args.obj_id,
                                   force=args.force, index_pattern=args.index_pattern)
     elif args.export_objs and args.obj_title:
         archimedes.export_to_disk(obj_type=args.obj_type, obj_title=args.obj_title,
                                   force=args.force, index_pattern=args.index_pattern)
+    elif args.export_objs and args.obj_alias:
+        archimedes.export_to_disk(obj_type=None, obj_alias=args.obj_alias,
+                                  force=args.force, index_pattern=args.index_pattern)
+
+    elif args.inspect:
+        objs = archimedes.inspect(args.local, args.remote)
+        for obj in objs:
+            print(obj)
+    elif args.registry:
+        if args.populate:
+            archimedes.populate_registry(args.force)
+        elif args.update:
+            archimedes.update_registry(args.alias, args.new_alias)
+        elif args.show:
+            if args.alias:
+                obj = archimedes.query_registry(alias=args.alias)
+                print(obj)
+            else:
+                objs = archimedes.list_registry(obj_type=args.obj_type)
+                for obj in objs:
+                    print(obj)
+        elif args.delete:
+            archimedes.delete_registry(args.alias)
+        elif args.clear:
+            archimedes.clear_registry()
 
     logging.info("Archimedes has finished.")
 

--- a/tests/test_archimedes.py
+++ b/tests/test_archimedes.py
@@ -36,8 +36,8 @@ from archimedes.manager import (INDEX_PATTERNS_FOLDER,
                                 VISUALIZATIONS_FOLDER)
 from archimedes.archimedes import (logger,
                                    Archimedes)
-from archimedes.errors import (ExportError,
-                               ImportError,
+from archimedes.errors import (DataExportError,
+                               DataImportError,
                                NotFoundError,
                                ObjectTypeError,
                                RegistryError)
@@ -494,14 +494,14 @@ class TestArchimedes(unittest.TestCase):
         """Test whether the method to import Kibana objects raises an error when the id and title is not provided"""
 
         archimedes = MockedArchimedes(KIBANA_URL, self.tmp_full)
-        with self.assertRaises(ImportError):
+        with self.assertRaises(DataImportError):
             archimedes.import_from_disk(VISUALIZATION)
 
     def test_import_from_disk_find_index_pattern(self):
         """Test whether an error is thrown when importing an index pattern with the flag `find` enabled"""
 
         archimedes = MockedArchimedes(KIBANA_URL, self.tmp_full)
-        with self.assertRaises(ImportError):
+        with self.assertRaises(DataImportError):
             archimedes.import_from_disk(INDEX_PATTERN, obj_id=INDEX_PATTERN_ID_TITLE, find=True)
 
     def test_import_from_disk_not_found(self):
@@ -646,7 +646,7 @@ class TestArchimedes(unittest.TestCase):
         """Test whether the method to export Kibana objects raises an error when the id and title is not provided"""
 
         archimedes = MockedArchimedes(KIBANA_URL, self.tmp_full)
-        with self.assertRaises(ExportError):
+        with self.assertRaises(DataExportError):
             archimedes.export_to_disk(VISUALIZATION)
 
     def test_export_from_disk_alias_not_found(self):

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -30,7 +30,7 @@ import requests
 from archimedes.clients.http import HEADERS
 from archimedes.clients.dashboard import (logger,
                                           Dashboard)
-from archimedes.errors import ExportError
+from archimedes.errors import DataExportError
 
 
 KIBANA_URL = 'http://example.com/'
@@ -86,7 +86,7 @@ class TestDashboard(unittest.TestCase):
                                status=200)
 
         client = Dashboard(KIBANA_URL)
-        with self.assertRaises(ExportError):
+        with self.assertRaises(DataExportError):
             _ = client.export_dashboard(DASHBOARD_ID)
 
     @httpretty.activate
@@ -101,7 +101,7 @@ class TestDashboard(unittest.TestCase):
                                status=400)
 
         client = Dashboard(KIBANA_URL)
-        with self.assertRaises(ExportError):
+        with self.assertRaises(DataExportError):
             _ = client.export_dashboard(DASHBOARD_ID)
 
     @httpretty.activate

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -67,7 +67,7 @@ class TestImportError(unittest.TestCase):
     def test_message(self):
         """Test ImportError message"""
 
-        e = errors.ImportError(cause='something went wrong during Import')
+        e = errors.DataImportError(cause='something went wrong during Import')
         self.assertEqual('something went wrong during Import', str(e))
 
 
@@ -76,7 +76,7 @@ class TestExportError(unittest.TestCase):
     def test_message(self):
         """Test ExportError message"""
 
-        e = errors.ExportError(cause='something went wrong during Export')
+        e = errors.DataExportError(cause='something went wrong during Export')
         self.assertEqual('something went wrong during Export', str(e))
 
 

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -311,6 +311,8 @@ class TestRegistry(unittest.TestCase):
         registry = Registry(self.tmp_path)
 
         tuples = [t for t in registry.find_all()]
+        tuples.sort()
+
         alias = tuples[0][0]
         self.assertEqual(alias, '1')
         alias = tuples[1][0]


### PR DESCRIPTION
This code allows to inspect the objects managed by Archimedes stored both on disk and in Kibana. Furthermore, it also allows to export and import objects using aliases, which are stored in a registry, thus avoiding the user to work with their IDs and titles. Finally, a set of operations is provided to manage the registry, such as:
 - populate, which copies the metadata of the objects in Kibana to the registry.
- show, which lists the content of the registry. Depending on the params, it
  can show the content of an alias or a set of aliases with a given object type.
- clear, which clears the registry. 
- delete, which removes only one alias.
- update, which updates the alias to a new one.