### PR TITLE
[tests] Fix CI tests for python 3.4 and 3.5

### DIFF
--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -111,6 +111,7 @@ class TestRegistry(unittest.TestCase):
 
         self.assertEqual(len(tuples), 11)
 
+        tuples.sort()
         alias = tuples[0][0]
         expected_alias = '1'
         self.assertEqual(alias, expected_alias)
@@ -143,6 +144,7 @@ class TestRegistry(unittest.TestCase):
 
         self.assertEqual(len(tuples), 8)
 
+        tuples.sort()
         alias = tuples[0][0]
         expected_alias = '2'
         self.assertEqual(alias, expected_alias)
@@ -317,6 +319,8 @@ class TestRegistry(unittest.TestCase):
         registry.update('1', 'x')
 
         tuples = [t for t in registry.find_all()]
+
+        tuples.sort()
         alias = tuples[0][0]
         self.assertEqual(alias, '2')
         alias = tuples[1][0]


### PR DESCRIPTION
This code fixes the tests for python 3.4 and 3.5. The fix sorts the tuples obtained by id to ensure that the comparison between the retrieved tuple and the expected one is consistent along the different python version used.