### PR TITLE
[archimedes] Bump to version 0.9.0

### DIFF
--- a/archimedes/_version.py
+++ b/archimedes/_version.py
@@ -1,2 +1,2 @@
 # Versions compliant with PEP 440 https://www.python.org/dev/peps/pep-0440
-__version__ = "0.8.0"
+__version__ = "0.9.0"

--- a/archimedes/archimedes.py
+++ b/archimedes/archimedes.py
@@ -325,9 +325,6 @@ class Archimedes:
         """Return the meta information of the Kibana objects stored in Kibana."""
 
         for obj in self.kibana.find_all():
-            if obj['type'] not in [VISUALIZATION, INDEX_PATTERN, SEARCH, DASHBOARD]:
-                continue
-
             meta_obj = KibanaObjMeta.create_from_obj(obj)
             yield meta_obj
 

--- a/archimedes/clients/saved_objects.py
+++ b/archimedes/clients/saved_objects.py
@@ -43,24 +43,31 @@ class SavedObjects(HttpClient):
     def __init__(self, base_url):
         super().__init__(base_url)
 
-    def fetch_objs(self, url):
-        """Find an object by its type and title.
+    def find(self, url, obj_type):
+        """Find an object by its type.
 
         :param url: saved_objects endpoint
+        :param obj_type: obj_type
 
         :returns an iterator of the saved objects
         """
         fetched_objs = 0
+        # The objects are retrieved one by one, since when an object cannot be retrieved, also all
+        # the remaining objects are not. This happens for the metadashboard and projectname objects,
+        # which cannot be retrieved because not recognized by the Kibana API.
         params = {
-            'page': 1
+            'page': 1,
+            'per_page': 1,
+            'type': obj_type
         }
 
+        find_url = urijoin(url, '_find')
         while True:
             try:
-                r_json = self.fetch(url, params=params)
+                r_json = self.fetch(find_url, params=params)
             except requests.exceptions.HTTPError as error:
                 if error.response.status_code == 500:
-                    logger.warning("Impossible to retrieve objects at page %s, url %s", params['page'], url)
+                    logger.warning("Impossible to retrieve object at page %s, url %s", params['page'], url)
                     params['page'] = params['page'] + 1
                     continue
                 else:

--- a/archimedes/kibana.py
+++ b/archimedes/kibana.py
@@ -136,9 +136,9 @@ class Kibana:
         url = urijoin(self.base_url, self.saved_objects.API_SAVED_OBJECTS_URL)
         found_obj = None
 
-        for page_objs in self.saved_objects.fetch_objs(url):
+        for page_objs in self.saved_objects.find(url, obj_type):
             for obj in page_objs:
-                if obj['type'] == obj_type and obj['attributes']['title'] == obj_title:
+                if obj['attributes']['title'] == obj_title:
                     found_obj = obj
                     break
 
@@ -164,9 +164,9 @@ class Kibana:
         url = urijoin(self.base_url, self.saved_objects.API_SAVED_OBJECTS_URL)
         found_obj = None
 
-        for page_objs in self.saved_objects.fetch_objs(url):
+        for page_objs in self.saved_objects.find(url, obj_type):
             for obj in page_objs:
-                if obj['type'] == obj_type and obj['id'] == obj_id:
+                if obj['id'] == obj_id:
                     found_obj = obj
                     break
 
@@ -186,6 +186,8 @@ class Kibana:
         """
         url = urijoin(self.base_url, self.saved_objects.API_SAVED_OBJECTS_URL)
 
-        for page_objs in self.saved_objects.fetch_objs(url):
-            for obj in page_objs:
-                yield obj
+        obj_types = [DASHBOARD, INDEX_PATTERN, SEARCH, VISUALIZATION]
+        for obj_type in obj_types:
+            for page_objs in self.saved_objects.find(url, obj_type):
+                for obj in page_objs:
+                    yield obj

--- a/archimedes/kibana_obj_meta.py
+++ b/archimedes/kibana_obj_meta.py
@@ -19,7 +19,11 @@
 #   Valerio Cosentino <valcos@bitergia.com>
 #
 
+import logging
 import json
+
+
+logger = logging.getLogger(__name__)
 
 
 class KibanaObjMeta:
@@ -64,8 +68,12 @@ class KibanaObjMeta:
         :param obj: Kibana object
         """
         updated_at = obj['updated_at'] if 'updated_at' in obj else None
+        title = obj['attributes'].get('title', None)
+        if not title:
+            msg = "Obj {} with id {} doesn't have a title".format(obj['type'], obj['id'])
+            logger.warning(msg)
 
-        return KibanaObjMeta(obj['id'], obj['attributes']['title'], obj['type'], obj['version'], updated_at)
+        return KibanaObjMeta(obj['id'], title, obj['type'], obj['version'], updated_at)
 
     @classmethod
     def create_from_registry(cls, entry):

--- a/tests/test_kibana.py
+++ b/tests/test_kibana.py
@@ -79,6 +79,14 @@ class MockedKibana(Kibana):
         self.dashboard = MockedDashboard(base_url, content)
         self.saved_objects = MockedSavedObjects(base_url, content)
 
+    def find_all(self):
+        objs = []
+        for obj in super().find_all():
+            found = [f['id'] for f in objs]
+            if obj['id'] not in found:
+                objs.append(obj)
+        return objs
+
 
 class MockedDashboard(Dashboard):
     def __init__(self, base_url, content):
@@ -97,7 +105,7 @@ class MockedSavedObjects(SavedObjects):
     def get_object(self, obj_type, obj_id):
         return self.content
 
-    def fetch_objs(self, url):
+    def find(self, url, obj_type):
         return self.content
 
 

--- a/tests/test_saved_objects.py
+++ b/tests/test_saved_objects.py
@@ -67,22 +67,22 @@ class TestSavedObjects(unittest.TestCase):
         saved_objs_page_3 = read_file('data/objects_empty')
 
         httpretty.register_uri(httpretty.GET,
-                               SAVED_OBJECTS_URL + '?page=3',
+                               SAVED_OBJECTS_URL + '/_find?page=3',
                                body=saved_objs_page_3,
                                status=200)
 
         httpretty.register_uri(httpretty.GET,
-                               SAVED_OBJECTS_URL + '?page=2',
+                               SAVED_OBJECTS_URL + '/_find?page=2',
                                body=saved_objs_page_2,
                                status=200)
 
         httpretty.register_uri(httpretty.GET,
-                               SAVED_OBJECTS_URL + '?page=1',
+                               SAVED_OBJECTS_URL + '/_find?page=1',
                                body=saved_objs_page_1,
                                status=200)
 
         client = SavedObjects(KIBANA_URL)
-        fetched_objs = [obj for page_objs in client.fetch_objs(SAVED_OBJECTS_URL) for obj in page_objs]
+        fetched_objs = [obj for page_objs in client.find(SAVED_OBJECTS_URL, obj_type='visualization') for obj in page_objs]
         self.assertEqual(len(fetched_objs), 4)
 
         obj = fetched_objs[0]
@@ -112,12 +112,12 @@ class TestSavedObjects(unittest.TestCase):
         saved_objs_empty = read_file('data/objects_empty')
 
         httpretty.register_uri(httpretty.GET,
-                               SAVED_OBJECTS_URL + '?page=1',
+                               SAVED_OBJECTS_URL + '/_find?page=1',
                                body=saved_objs_empty,
                                status=200)
 
         client = SavedObjects(KIBANA_URL)
-        fetched_objs = [obj for page_objs in client.fetch_objs(SAVED_OBJECTS_URL) for obj in page_objs]
+        fetched_objs = [obj for page_objs in client.find(SAVED_OBJECTS_URL, obj_type='dashboard') for obj in page_objs]
         self.assertEqual(len(fetched_objs), 0)
 
     @httpretty.activate
@@ -128,18 +128,18 @@ class TestSavedObjects(unittest.TestCase):
         saved_objs_empty = read_file('data/objects_empty')
 
         httpretty.register_uri(httpretty.GET,
-                               SAVED_OBJECTS_URL + '?page=2',
+                               SAVED_OBJECTS_URL + '/_find?page=2',
                                body=saved_objs_empty,
                                status=200)
 
         httpretty.register_uri(httpretty.GET,
-                               SAVED_OBJECTS_URL + '?page=1',
+                               SAVED_OBJECTS_URL + '/_find?page=1',
                                body=saved_objs_error,
                                status=200)
 
         client = SavedObjects(KIBANA_URL)
         with self.assertLogs(logger, level='ERROR') as cm:
-            _ = [obj for page_objs in client.fetch_objs(SAVED_OBJECTS_URL) for obj in page_objs]
+            _ = [obj for page_objs in client.find(SAVED_OBJECTS_URL, obj_type='dashboard') for obj in page_objs]
             self.assertEqual(cm.output[0],
                              'ERROR:archimedes.clients.saved_objects:Impossible to retrieve objects at page 1, '
                              'url http://example.com/api/saved_objects, An internal server error occurred')
@@ -151,13 +151,13 @@ class TestSavedObjects(unittest.TestCase):
         saved_objs_page = read_file('data/objects_1')
 
         httpretty.register_uri(httpretty.GET,
-                               SAVED_OBJECTS_URL,
+                               SAVED_OBJECTS_URL + '/_find',
                                body=saved_objs_page,
                                status=404)
 
         client = SavedObjects(KIBANA_URL)
         with self.assertRaises(requests.exceptions.HTTPError):
-            _ = [obj for page_objs in client.fetch_objs(SAVED_OBJECTS_URL) for obj in page_objs]
+            _ = [obj for page_objs in client.find(SAVED_OBJECTS_URL, obj_type='dashboard') for obj in page_objs]
 
     @httpretty.activate
     def test_fetch_objs_http_error_500(self):
@@ -168,26 +168,26 @@ class TestSavedObjects(unittest.TestCase):
         saved_objs_page_3 = read_file('data/objects_empty')
 
         httpretty.register_uri(httpretty.GET,
-                               SAVED_OBJECTS_URL + '?page=3',
+                               SAVED_OBJECTS_URL + '/_find?page=3',
                                body=saved_objs_page_3,
                                status=200)
 
         httpretty.register_uri(httpretty.GET,
-                               SAVED_OBJECTS_URL + '?page=2',
+                               SAVED_OBJECTS_URL + '/_find?page=2',
                                body=saved_objs_page_2,
                                status=500)
 
         httpretty.register_uri(httpretty.GET,
-                               SAVED_OBJECTS_URL + '?page=1',
+                               SAVED_OBJECTS_URL + '/_find?page=1',
                                body=saved_objs_page_1,
                                status=200)
 
         client = SavedObjects(KIBANA_URL)
         with self.assertLogs(logger) as cm:
-            _ = [obj for page_objs in client.fetch_objs(SAVED_OBJECTS_URL) for obj in page_objs]
+            _ = [obj for page_objs in client.find(SAVED_OBJECTS_URL, obj_type='dashboard') for obj in page_objs]
 
         self.assertEqual(cm.output[0],
-                         'WARNING:archimedes.clients.saved_objects:Impossible to retrieve objects at page 2, '
+                         'WARNING:archimedes.clients.saved_objects:Impossible to retrieve object at page 2, '
                          'url http://example.com/api/saved_objects')
 
     @httpretty.activate


### PR DESCRIPTION
This code updates archimedes to be able to work with Kibana 6.8 API.

The method `fetch_objs` in the class `saved_objects` has been renamed to `find` and aligned to the endpoint `_find` of the SavedObjects API. This change was needed since the previous call to the API wasn't working anymore.

Tests have been updated accordingly.