### PR TITLE
[registry] Allow to create a registry on incomplete paths

### DIFF
--- a/archimedes/registry.py
+++ b/archimedes/registry.py
@@ -59,6 +59,8 @@ class Registry:
         :param root_path: path where the registry will be stored
         """
         self.path = os.path.join(root_path, REGISTRY_NAME)
+        if not os.path.exists(root_path):
+            os.makedirs(root_path)
 
         if not os.path.exists(self.path):
             self.__create_registry()

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -98,6 +98,19 @@ class TestRegistry(unittest.TestCase):
         self.assertEqual(registry.path, registry_path)
         self.assertTrue(os.path.exists(registry_path))
 
+    def test_initialization_nested_dir(self):
+        """Test whether a nested directory is created when initializing the registry"""
+
+        nested_path = os.path.join(self.tmp_path, 'nested')
+        registry_path = os.path.join(self.tmp_path, 'nested', REGISTRY_NAME)
+        self.assertFalse(os.path.exists(nested_path))
+        self.assertFalse(os.path.exists(registry_path))
+
+        registry = Registry(nested_path)
+
+        self.assertEqual(registry.path, registry_path)
+        self.assertTrue(os.path.exists(registry_path))
+
     def test_find_all(self):
         """Test whether the find method returns all entries when no obj type is given"""
 


### PR DESCRIPTION
This code creates all missing sub-folders defined in the root directory of Archimedes, thus granting
the creation of the registry.

Tests have been added accordingly.