### PR TITLE
Saved objects improvements

### DIFF
--- a/archimedes/clients/saved_objects.py
+++ b/archimedes/clients/saved_objects.py
@@ -43,10 +43,9 @@ class SavedObjects(HttpClient):
     def __init__(self, base_url):
         super().__init__(base_url)
 
-    def find(self, url, obj_type):
+    def find(self, obj_type):
         """Find an object by its type.
 
-        :param url: saved_objects endpoint
         :param obj_type: obj_type
 
         :returns an iterator of the saved objects
@@ -61,13 +60,13 @@ class SavedObjects(HttpClient):
             'type': obj_type
         }
 
-        find_url = urijoin(url, self.API_FIND_ENDPOINT)
+        find_url = urijoin(self.base_url, self.API_SAVED_OBJECTS_URL, self.API_FIND_ENDPOINT)
         while True:
             try:
                 r_json = self.fetch(find_url, params=params)
             except requests.exceptions.HTTPError as error:
                 if error.response.status_code == 500:
-                    logger.warning("Impossible to retrieve object at page %s, url %s", params['page'], url)
+                    logger.warning("Impossible to retrieve object at page %s, url %s", params['page'], find_url)
                     params['page'] = params['page'] + 1
                     continue
                 else:
@@ -75,7 +74,7 @@ class SavedObjects(HttpClient):
 
             if 'statusCode' in r_json:
                 logger.error("Impossible to retrieve objects at page %s, url %s, %s",
-                             params['page'], url, r_json['message'])
+                             params['page'], find_url, r_json['message'])
                 params['page'] = params['page'] + 1
                 continue
 

--- a/archimedes/clients/saved_objects.py
+++ b/archimedes/clients/saved_objects.py
@@ -125,21 +125,18 @@ class SavedObjects(HttpClient):
             else:
                 raise error
 
-    def update_object(self, obj_type, obj_id, attr, value):
-        """Update an attribute of a target object of a given type and id.
+    def update_object(self, obj_type, obj_id, attributes):
+        """Update the atttributes of a target object of a given type and id.
 
         :param obj_type: type of the target object
         :param obj_id: ID of the target object
-        :param attr: attribute to update
-        :param value: new value of attribute
+        :param attributes: a dict containing the attributes to be updated
 
         :returns the updated object
         """
         url = urijoin(self.base_url, self.API_SAVED_OBJECTS_URL, obj_type, obj_id)
         params = {
-            "attributes": {
-                attr: value
-            }
+            "attributes": attributes
         }
         r = None
 
@@ -150,8 +147,7 @@ class SavedObjects(HttpClient):
             if error.response.status_code == 404:
                 logger.warning("No %s found with id: %s", obj_type, obj_id)
             elif error.response.status_code == 400:
-                logger.warning("Impossible to update attribute %s with value %s, for %s with id %s",
-                               attr, value, obj_type, obj_id)
+                logger.warning("Impossible to update the object %s with id %s", obj_type, obj_id)
             else:
                 raise error
 

--- a/archimedes/clients/saved_objects.py
+++ b/archimedes/clients/saved_objects.py
@@ -38,7 +38,7 @@ class SavedObjects(HttpClient):
     :param base_url: the Kibana URL
     """
     API_SAVED_OBJECTS_URL = 'api/saved_objects'
-    API_SEARCH_COMMAND = '_search'
+    API_FIND_ENDPOINT = '_find'
 
     def __init__(self, base_url):
         super().__init__(base_url)
@@ -61,7 +61,7 @@ class SavedObjects(HttpClient):
             'type': obj_type
         }
 
-        find_url = urijoin(url, '_find')
+        find_url = urijoin(url, self.API_FIND_ENDPOINT)
         while True:
             try:
                 r_json = self.fetch(find_url, params=params)
@@ -154,5 +154,33 @@ class SavedObjects(HttpClient):
                                attr, value, obj_type, obj_id)
             else:
                 raise error
+
+        return r
+
+    def create_object(self, obj_type, obj_id, attributes, overwrite=False):
+        """Create an object of a given type and id with a set of attributes.
+
+        :param obj_type: type of the new obj
+        :param obj_id: ID of the new obj
+        :param attributes: a dict containing the attributes of the new obj
+        :param overwrite: if True, will overwrite the obj with the same ID
+
+        :returns the created obj
+        """
+        url = urijoin(self.base_url, self.API_SAVED_OBJECTS_URL, obj_type, obj_id)
+        data = {
+            "attributes": attributes
+        }
+
+        params = {
+            "overwrite": overwrite
+        }
+
+        try:
+            r = self.post(url, data=data, params=params)
+            logger.info("Object %s with id %s create", obj_type, obj_id)
+        except requests.exceptions.HTTPError as error:
+            logger.error("Object %s with id %s not created: %s", obj_type, obj_id, error)
+            raise error
 
         return r

--- a/archimedes/kibana.py
+++ b/archimedes/kibana.py
@@ -136,7 +136,7 @@ class Kibana:
         url = urijoin(self.base_url, self.saved_objects.API_SAVED_OBJECTS_URL)
         found_obj = None
 
-        for page_objs in self.saved_objects.find(url, obj_type):
+        for page_objs in self.saved_objects.find(obj_type):
             for obj in page_objs:
                 if obj['attributes']['title'] == obj_title:
                     found_obj = obj
@@ -164,7 +164,7 @@ class Kibana:
         url = urijoin(self.base_url, self.saved_objects.API_SAVED_OBJECTS_URL)
         found_obj = None
 
-        for page_objs in self.saved_objects.find(url, obj_type):
+        for page_objs in self.saved_objects.find(obj_type):
             for obj in page_objs:
                 if obj['id'] == obj_id:
                     found_obj = obj
@@ -184,10 +184,8 @@ class Kibana:
 
         :returns a generator of Kibana objects
         """
-        url = urijoin(self.base_url, self.saved_objects.API_SAVED_OBJECTS_URL)
-
         obj_types = [DASHBOARD, INDEX_PATTERN, SEARCH, VISUALIZATION]
         for obj_type in obj_types:
-            for page_objs in self.saved_objects.find(url, obj_type):
+            for page_objs in self.saved_objects.find(obj_type):
                 for obj in page_objs:
                     yield obj

--- a/tests/test_kibana.py
+++ b/tests/test_kibana.py
@@ -105,7 +105,7 @@ class MockedSavedObjects(SavedObjects):
     def get_object(self, obj_type, obj_id):
         return self.content
 
-    def find(self, url, obj_type):
+    def find(self, obj_type):
         return self.content
 
 

--- a/tests/test_saved_objects.py
+++ b/tests/test_saved_objects.py
@@ -82,7 +82,7 @@ class TestSavedObjects(unittest.TestCase):
                                status=200)
 
         client = SavedObjects(KIBANA_URL)
-        fetched_objs = [obj for page_objs in client.find(SAVED_OBJECTS_URL, obj_type='visualization') for obj in page_objs]
+        fetched_objs = [obj for page_objs in client.find(obj_type='visualization') for obj in page_objs]
         self.assertEqual(len(fetched_objs), 4)
 
         obj = fetched_objs[0]
@@ -117,7 +117,7 @@ class TestSavedObjects(unittest.TestCase):
                                status=200)
 
         client = SavedObjects(KIBANA_URL)
-        fetched_objs = [obj for page_objs in client.find(SAVED_OBJECTS_URL, obj_type='dashboard') for obj in page_objs]
+        fetched_objs = [obj for page_objs in client.find(obj_type='dashboard') for obj in page_objs]
         self.assertEqual(len(fetched_objs), 0)
 
     @httpretty.activate
@@ -139,10 +139,10 @@ class TestSavedObjects(unittest.TestCase):
 
         client = SavedObjects(KIBANA_URL)
         with self.assertLogs(logger, level='ERROR') as cm:
-            _ = [obj for page_objs in client.find(SAVED_OBJECTS_URL, obj_type='dashboard') for obj in page_objs]
+            _ = [obj for page_objs in client.find(obj_type='dashboard') for obj in page_objs]
             self.assertEqual(cm.output[0],
                              'ERROR:archimedes.clients.saved_objects:Impossible to retrieve objects at page 1, '
-                             'url http://example.com/api/saved_objects, An internal server error occurred')
+                             'url http://example.com/api/saved_objects/_find, An internal server error occurred')
 
     @httpretty.activate
     def test_fetch_objs_http_error(self):
@@ -157,7 +157,7 @@ class TestSavedObjects(unittest.TestCase):
 
         client = SavedObjects(KIBANA_URL)
         with self.assertRaises(requests.exceptions.HTTPError):
-            _ = [obj for page_objs in client.find(SAVED_OBJECTS_URL, obj_type='dashboard') for obj in page_objs]
+            _ = [obj for page_objs in client.find(obj_type='dashboard') for obj in page_objs]
 
     @httpretty.activate
     def test_fetch_objs_http_error_500(self):
@@ -184,11 +184,11 @@ class TestSavedObjects(unittest.TestCase):
 
         client = SavedObjects(KIBANA_URL)
         with self.assertLogs(logger) as cm:
-            _ = [obj for page_objs in client.find(SAVED_OBJECTS_URL, obj_type='dashboard') for obj in page_objs]
+            _ = [obj for page_objs in client.find(obj_type='dashboard') for obj in page_objs]
 
         self.assertEqual(cm.output[0],
                          'WARNING:archimedes.clients.saved_objects:Impossible to retrieve object at page 2, '
-                         'url http://example.com/api/saved_objects')
+                         'url http://example.com/api/saved_objects/_find')
 
     @httpretty.activate
     def test_get_object(self):

--- a/tests/test_saved_objects.py
+++ b/tests/test_saved_objects.py
@@ -294,8 +294,9 @@ class TestSavedObjects(unittest.TestCase):
         """Test the method update_object"""
 
         obj_data = read_file('data/object_index-pattern')
-        obj_attr = "version"
-        obj_new_value = "2"
+        attributes = {
+            "version": "2"
+        }
 
         httpretty.register_uri(httpretty.PUT,
                                OBJECT_URL,
@@ -304,7 +305,7 @@ class TestSavedObjects(unittest.TestCase):
 
         client = SavedObjects(KIBANA_URL)
         with self.assertLogs(logger, level='INFO') as cm:
-            obj = client.update_object(OBJECT_TYPE, OBJECT_ID, obj_attr, obj_new_value)
+            obj = client.update_object(OBJECT_TYPE, OBJECT_ID, attributes)
             self.assertEqual(cm.output[0],
                              'INFO:archimedes.clients.saved_objects:'
                              'Object ' + OBJECT_TYPE + ' with id ' + OBJECT_ID + ' updated')
@@ -315,8 +316,9 @@ class TestSavedObjects(unittest.TestCase):
         """Test whether a warning is logged when the object is not found"""
 
         obj_data = read_file('data/object_index-pattern')
-        obj_attr = "version"
-        obj_new_value = "2"
+        attributes = {
+            "version": "2"
+        }
 
         httpretty.register_uri(httpretty.PUT,
                                OBJECT_URL,
@@ -325,7 +327,7 @@ class TestSavedObjects(unittest.TestCase):
 
         client = SavedObjects(KIBANA_URL)
         with self.assertLogs(logger, level='WARNING') as cm:
-            obj = client.update_object(OBJECT_TYPE, OBJECT_ID, obj_attr, obj_new_value)
+            obj = client.update_object(OBJECT_TYPE, OBJECT_ID, attributes)
             self.assertEqual(cm.output[0],
                              'WARNING:archimedes.clients.saved_objects:'
                              'No ' + OBJECT_TYPE + ' found with id: ' + OBJECT_ID)
@@ -336,8 +338,9 @@ class TestSavedObjects(unittest.TestCase):
         """Test whether a warning is logged when the object is not updated"""
 
         obj_data = read_file('data/object_index-pattern')
-        obj_attr = "version"
-        obj_new_value = "2"
+        attributes = {
+            "version": "2"
+        }
 
         httpretty.register_uri(httpretty.PUT,
                                OBJECT_URL,
@@ -346,10 +349,9 @@ class TestSavedObjects(unittest.TestCase):
 
         client = SavedObjects(KIBANA_URL)
         with self.assertLogs(logger, level='WARNING') as cm:
-            obj = client.update_object(OBJECT_TYPE, OBJECT_ID, obj_attr, obj_new_value)
+            obj = client.update_object(OBJECT_TYPE, OBJECT_ID, attributes)
             self.assertEqual(cm.output[0], 'WARNING:archimedes.clients.saved_objects:Impossible to update '
-                                           'attribute ' + obj_attr + ' with value ' + obj_new_value + ', '
-                                           'for ' + OBJECT_TYPE + ' with id ' + OBJECT_ID)
+                                           'the object ' + OBJECT_TYPE + ' with id ' + OBJECT_ID)
             self.assertIsNone(obj)
 
     @httpretty.activate
@@ -357,8 +359,9 @@ class TestSavedObjects(unittest.TestCase):
         """Test whether an exception is thrown when the HTTP error is not 404 or 400"""
 
         obj_data = read_file('data/object_index-pattern')
-        obj_attr = "version"
-        obj_new_value = "2"
+        attributes = {
+            "version": "2"
+        }
 
         httpretty.register_uri(httpretty.PUT,
                                OBJECT_URL,
@@ -367,7 +370,7 @@ class TestSavedObjects(unittest.TestCase):
 
         client = SavedObjects(KIBANA_URL)
         with self.assertRaises(requests.exceptions.HTTPError):
-            _ = client.update_object(OBJECT_TYPE, OBJECT_ID, obj_attr, obj_new_value)
+            _ = client.update_object(OBJECT_TYPE, OBJECT_ID, attributes)
 
     @httpretty.activate
     def test_create_object(self):


### PR DESCRIPTION
This code proposes some improvements for the wrapper around the SavedObjects API.

- Remove param `url` from `find` method's signature. Now the find url is composed of the base_url, plus constants `API_SAVED_OBJECTS_URL` and `API_FIND_ENDPOINT`.

- Modify the method `update_object` to let update multiple attributes at the same time.

- Add create object method to allow creating a Kibana object from SavedObjects instances. This is useful for creating the configuration settings of Kibiter.

Tests have been added accordingly.
